### PR TITLE
Cross build for scala 2.10 and 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # and
 language: scala
 scala:
+    - 2.10.5
     - 2.11.6
 branches:
   only:
@@ -15,4 +16,4 @@ jdk:
     - oraclejdk8
 
 script:
-    - sbt test
+    - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.11.6"
 
+crossScalaVersions := Seq("2.10.5", "2.11.6")
+
 organization := "com.nitro"
 
 resolvers ++= Seq("Typesafe repository releases" at "http://repo.typesafe.com/typesafe/releases/",


### PR DESCRIPTION
Allow cross build to enable projects still using scala 2.10 to use the library 